### PR TITLE
feat: Font Ligature association

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,10 @@
           "default": "both",
           "description": "Filter theme styles."
         },
+        "theme-explorer.fontLigatureAssociation": {
+          "type": "object",
+          "description": "Association of a font and a font ligature configuration."
+        },
         "theme-explorer.randomType": {
           "type": "string",
           "enum": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,7 +171,30 @@ class FontTree extends Tree<Font> implements vscode.TreeDragAndDropController<Fo
         } else {
             fonts.unshift(font.name);
         }
-        updateConfig("editor.fontFamily", Font.toString(fonts), config, showError);
+        updateConfig(
+            "editor.fontFamily",
+            Font.toString(fonts),
+            config,
+            showError,
+        );
+
+        const fontLigatures: object = config.get(
+            "theme-explorer.fontLigatureAssociation",
+            {},
+        );
+        let liga = "";
+        Object.entries(fontLigatures).forEach(([key, value]) => {
+            if (key === fonts[0]) {
+                liga = value;
+            }
+        });
+
+                updateConfig(
+                    "editor.fontLigatures",
+            liga,
+                    config,
+                    showError,
+                );
     }
 }
 


### PR DESCRIPTION
Add a new config to create an association of what ligatures should be used for each font, and change the editor configuration based on that. If the font are not listed, default to an empty string.

I'm not sure that is something you want, but it was something I did needed, since I like to keep changing fonts and many have specific configurations related to ligatures

### Example of the new configuration

```json
"theme-explorer.fontLigatureAssociation": {
        "Victor Mono": "'ss01', 'ss02', 'ss06'",
        "Fira Code": "'cv02', 'cv14', 'cv25', 'cv26', 'cv28', 'cv32', 'ss01', 'ss02', 'ss06', 'zero'",
        "FiraCode Nerd Font": "'cv02', 'cv14', 'cv25', 'cv26', 'cv28', 'cv32', 'ss01', 'ss02', 'ss06', 'zero'",
        "JetBrains Mono": "'zero'",
        "Monaspace Argon": "'cv01' 2, 'cv32', 'calt', 'ss01', 'ss02', 'ss03', 'ss04', 'ss05', 'ss07', 'ss08', 'ss09', 'liga'",
        "Monaspace Neon": "'cv01' 2, 'cv32', 'calt', 'ss01', 'ss02', 'ss03', 'ss04', 'ss05', 'ss07', 'ss08', 'ss09', 'liga'",
        "Monaspace Xenon": "'cv01' 2, 'cv32', 'calt', 'ss01', 'ss02', 'ss03', 'ss04', 'ss05', 'ss07', 'ss08', 'ss09', 'liga'",
        "Monaspace Radon": "'cv01' 2, 'cv32', 'calt', 'ss01', 'ss02', 'ss03', 'ss04', 'ss05', 'ss07', 'ss08', 'ss09', 'liga'",
        "Monaspace Krypton": "'cv01' 2, 'cv32', 'calt', 'ss01', 'ss02', 'ss03', 'ss04', 'ss05', 'ss07', 'ss08', 'ss09', 'liga'",
    },
```

It in action:

![Mar-01-2025 19-24-37](https://github.com/user-attachments/assets/d4f1f666-4f74-40c6-bc76-47382c733589)
